### PR TITLE
rosunit python 3 support

### DIFF
--- a/tools/rosunit/src/rosunit/xmlrunner.py
+++ b/tools/rosunit/src/rosunit/xmlrunner.py
@@ -199,7 +199,8 @@ class _XMLTestResult(unittest.TestResult):
         output and standard error streams must be passed in.a
 
         """
-        stream.write(ET.tostring(self.xml(time_taken, out, err).getroot(), encoding='utf-8', method='xml'))
+        root = self.xml(time_taken, out, err).getroot()
+        stream.write(ET.tostring(root, encoding='utf-8', method='xml').decode('utf-8'))
 
     def print_report_text(self, stream, time_taken, out, err):
         """Prints the text report to the supplied stream.


### PR DESCRIPTION
Address https://github.com/ros/ros/issues/158 by explicitly decoding to utf-8 before writing to stream.

This is a typical Python 2 -> 3 issue.   Before this fix, Python 2 would return a `str` and Python 3 would return `bytes`. `bytes` is not supported for writing to streams like stdout in Python 3.

This fix  explicitly decodes to utf-8 before writing, so in Python 2 we're writing a `unicode` object and in Python 3 we're writing a `str` object.